### PR TITLE
Fix sharing resources

### DIFF
--- a/pylana/dashboards.py
+++ b/pylana/dashboards.py
@@ -163,6 +163,8 @@ class DashboardAPI(ResourceAPI):
                 It is ignored when ids are passed.
             ids: 
                 A list of strings denoting dashboard ids.
+            **kwargs:
+                Keyword arguments passed to requests functions.
                 
         Returns:
             A list of request responses of the calls to the lana api.
@@ -174,17 +176,43 @@ class DashboardAPI(ResourceAPI):
     def share_dashboard(self, dashboard_id: str, organization_ids: List[str],
                         **kwargs) -> Response:
         """
-        Share a dashboard with users by ids.
+        Share a dashboard with organizations by ids.
         Args:
             dashboard_id:
                 A string denoting the pageId of the dashboard.
             organization_ids:
                 A list of strings denoting ids of organizations to share with.
+            **kwargs:
+                Keyword arguments passed to requests functions.
+
         Returns:
             The requests response of the lana api call.
         """
         body = {
             "shareWithOrganizations": organization_ids
+        }
+        return self.patch(f"/api/v2/dashboards/{dashboard_id}/sharing", json=body,
+                          **kwargs)
+
+    def unshare_dashboard(self, dashboard_id: str, organization_ids: List[str],
+                          **kwargs) -> Response:
+        """
+        Unshare a dashboard with users by ids.
+
+        Args:
+            dashboard_id:
+                A string denoting the pageId of the dashboard.
+            organization_ids:
+                A list of strings denoting ids of organizations to unshare the
+                dashboard with.
+            **kwargs:
+                Keyword arguments passed to requests functions.
+
+        Returns:
+            The requests response of the lana api call.
+        """
+        body = {
+            "unshareWithOrganizations": organization_ids
         }
         return self.patch(f"/api/v2/dashboards/{dashboard_id}/sharing", json=body,
                           **kwargs)

--- a/pylana/dashboards.py
+++ b/pylana/dashboards.py
@@ -192,7 +192,7 @@ class DashboardAPI(ResourceAPI):
     def connect_dashboard(self, log_id, dashboard_id, **kwargs) \
             -> Response:
         """
-        Connect a shiny dashboard with a log by their ids.
+        Connect a dashboard with a log by their ids.
         
         Args:
             log_id: 

--- a/pylana/dashboards.py
+++ b/pylana/dashboards.py
@@ -27,7 +27,7 @@ class DashboardAPI(ResourceAPI):
     def get_dashboard_ids(self, contains: str = '.*', **kwargs) \
             -> List[str]:
         """
-        List dashboard ids with matching names.
+        List ids of dashboard pages with matching names.
 
         Args:
            contains:  
@@ -37,7 +37,7 @@ class DashboardAPI(ResourceAPI):
                 Keyword arguments passed to requests functions.
             
         Returns:
-            A list of strings denoting dashboard pageIds.
+            A list of strings denoting the ids of the dashboard pages.
         """
         return self.get_resource_ids('v2/dashboards', contains, **kwargs)
 
@@ -53,7 +53,7 @@ class DashboardAPI(ResourceAPI):
                 Keyword arguments passed to requests functions.
             
         Returns: 
-            A string denoting the dashboard pageId.
+            A string denoting the id of the dashboard page.
 
         Raises:
             Exception:
@@ -100,7 +100,7 @@ class DashboardAPI(ResourceAPI):
                 matched against the dashboard name. 
                 Matching several names raises an exception.
             dashboard_id: 
-                A string denoting the pageId of the dashboard.
+                A string denoting the id of the dashboard page.
             **kwargs: 
                 Keyword arguments passed to requests functions.
             
@@ -122,7 +122,7 @@ class DashboardAPI(ResourceAPI):
                 matched against the dashboard name. 
                 Matching several names raises an exception.
             dashboard_id: 
-                A string denoting the pageId of the dashboard.
+                A string denoting the id of the dashboard page.
             **kwargs: 
                 Keyword arguments passed to requests functions.
             
@@ -141,7 +141,7 @@ class DashboardAPI(ResourceAPI):
         
         Args:
             dashboard_id: 
-                A string denoting the dashboard.
+                A string denoting the id of the dashboard page.
             **kwargs: 
                 Keyword arguments passed to requests functions.
 
@@ -162,7 +162,7 @@ class DashboardAPI(ResourceAPI):
                 A string denoting a regular expression. 
                 It is ignored when ids are passed.
             ids: 
-                A list of strings denoting dashboard ids.
+                A list of strings denoting ids of dashboard pages.
             **kwargs:
                 Keyword arguments passed to requests functions.
                 
@@ -179,7 +179,7 @@ class DashboardAPI(ResourceAPI):
         Share a dashboard with organizations by ids.
         Args:
             dashboard_id:
-                A string denoting the pageId of the dashboard.
+                A string denoting the id of the dashboard page.
             organization_ids:
                 A list of strings denoting ids of organizations to share with.
             **kwargs:
@@ -201,7 +201,7 @@ class DashboardAPI(ResourceAPI):
 
         Args:
             dashboard_id:
-                A string denoting the pageId of the dashboard.
+                A string denoting the id of the dashboard page.
             organization_ids:
                 A list of strings denoting ids of organizations to unshare the
                 dashboard with.
@@ -226,7 +226,7 @@ class DashboardAPI(ResourceAPI):
             log_id: 
                 A string denoting the id of the log in LANA.
             dashboard_id:
-                A string denoting the id of the dashboard.
+                A string denoting the id of the dashboard page.
             **kwargs: 
                 Keyword arguments passed to requests functions.
 

--- a/pylana/dashboards.py
+++ b/pylana/dashboards.py
@@ -37,7 +37,7 @@ class DashboardAPI(ResourceAPI):
                 Keyword arguments passed to requests functions.
             
         Returns:
-            A list of strings denoting dashboard ids.
+            A list of strings denoting dashboard pageIds.
         """
         return self.get_resource_ids('v2/dashboards', contains, **kwargs)
 
@@ -53,7 +53,7 @@ class DashboardAPI(ResourceAPI):
                 Keyword arguments passed to requests functions.
             
         Returns: 
-            A string denoting the dashboard id.
+            A string denoting the dashboard pageId.
 
         Raises:
             Exception:
@@ -100,7 +100,7 @@ class DashboardAPI(ResourceAPI):
                 matched against the dashboard name. 
                 Matching several names raises an exception.
             dashboard_id: 
-                A string denoting the id of the dashboard.
+                A string denoting the pageId of the dashboard.
             **kwargs: 
                 Keyword arguments passed to requests functions.
             
@@ -122,7 +122,7 @@ class DashboardAPI(ResourceAPI):
                 matched against the dashboard name. 
                 Matching several names raises an exception.
             dashboard_id: 
-                A string denoting the id of the dashboard.
+                A string denoting the pageId of the dashboard.
             **kwargs: 
                 Keyword arguments passed to requests functions.
             
@@ -130,7 +130,7 @@ class DashboardAPI(ResourceAPI):
             A list with the dashboard items as dicts (items are referenced as
             charts in LANA Process Mining)
         """
-        dashboard = self.get_dashboard(contains, dashboard_id, **kwargs)
+        dashboard = self.describe_dashboard(contains, dashboard_id, **kwargs)
         
         return dashboard["items"]
 
@@ -171,30 +171,22 @@ class DashboardAPI(ResourceAPI):
                                      **kwargs)
 
     # TODO consider sharing by names
-    def share_dashboard(self, dashboard_id: str,
-                        user_ids: List[str], organization_ids: List[str],
+    def share_dashboard(self, dashboard_id: str, organization_ids: List[str],
                         **kwargs) -> Response:
         """
         Share a dashboard with users by ids.
-
         Args:
             dashboard_id:
-                A string denoting the id of the dashboard.
-            user_ids:
-                A list of strings denoting ids of users to share with.
-            organization_ids: 
+                A string denoting the pageId of the dashboard.
+            organization_ids:
                 A list of strings denoting ids of organizations to share with.
-
         Returns:
             The requests response of the lana api call.
         """
         body = {
-            "sharedInformation": {
-                "userIds": user_ids,
-                "organizationIds": organization_ids
-            }
+            "shareWithOrganizations": organization_ids
         }
-        return self.patch(f"/api/v2/dashboards/{dashboard_id}", json=body, 
+        return self.patch(f"/api/v2/dashboards/{dashboard_id}/sharing", json=body,
                           **kwargs)
 
     def connect_dashboard(self, log_id, dashboard_id, **kwargs) \

--- a/pylana/dashboards.py
+++ b/pylana/dashboards.py
@@ -197,7 +197,7 @@ class DashboardAPI(ResourceAPI):
     def unshare_dashboard(self, dashboard_id: str, organization_ids: List[str],
                           **kwargs) -> Response:
         """
-        Unshare a dashboard with users by ids.
+        Unshare a dashboard with organizations by ids.
 
         Args:
             dashboard_id:

--- a/pylana/shiny_dashboards.py
+++ b/pylana/shiny_dashboards.py
@@ -158,6 +158,9 @@ class ShinyDashboardAPI(ResourceAPI):
                 It is ignored when ids are passed.
             ids: 
                 A list of strings denoting shiny dashboard ids.
+            **kwargs:
+                Keyword arguments passed to requests functions.
+
         Returns:
             A list of request responses of the calls to the lana api.
         """
@@ -175,6 +178,8 @@ class ShinyDashboardAPI(ResourceAPI):
                 A string denoting the id of the shiny dashboard.
             organization_ids:
                 A list of strings denoting ids of organizations to share with.
+            **kwargs:
+                Keyword arguments passed to requests functions.
 
         Returns:
             The requests response of the lana api call.
@@ -196,6 +201,8 @@ class ShinyDashboardAPI(ResourceAPI):
             organization_ids:
                 A list of strings denoting ids of organizations to unshare the
                 shiny dashboard with.
+            **kwargs:
+                Keyword arguments passed to requests functions.
 
         Returns:
             The requests response of the lana api call.

--- a/pylana/shiny_dashboards.py
+++ b/pylana/shiny_dashboards.py
@@ -169,16 +169,39 @@ class ShinyDashboardAPI(ResourceAPI):
                               **kwargs) -> Response:
         """
         Share a shiny dashboard with organizations by ids.
+
         Args:
             shiny_dashboard_id:
                 A string denoting the id of the shiny dashboard.
             organization_ids:
                 A list of strings denoting ids of organizations to share with.
+
         Returns:
             The requests response of the lana api call.
         """
         body = {
             "shareWithOrganizations": organization_ids
+        }
+        return self.patch(f"/api/shiny-dashboards/{shiny_dashboard_id}/sharing",
+                          json=body, **kwargs)
+
+    def unshare_shiny_dashboard(self, shiny_dashboard_id: str, organization_ids: List[str],
+                                **kwargs) -> Response:
+        """
+        Unshare a shiny dashboard with organizations by ids.
+
+        Args:
+            shiny_dashboard_id:
+                A string denoting the id of the shiny dashboard.
+            organization_ids:
+                A list of strings denoting ids of organizations to unshare the
+                shiny dashboard with.
+
+        Returns:
+            The requests response of the lana api call.
+        """
+        body = {
+            "unshareWithOrganizations": organization_ids
         }
         return self.patch(f"/api/shiny-dashboards/{shiny_dashboard_id}/sharing",
                           json=body, **kwargs)

--- a/pylana/shiny_dashboards.py
+++ b/pylana/shiny_dashboards.py
@@ -165,31 +165,23 @@ class ShinyDashboardAPI(ResourceAPI):
                                      **kwargs)
 
     # TODO consider sharing by names
-    def share_shiny_dashboard(self, shiny_dashboard_id: str,
-                              user_ids: List[str], organization_ids: List[str], 
+    def share_shiny_dashboard(self, shiny_dashboard_id: str, organization_ids: List[str],
                               **kwargs) -> Response:
         """
-        Share a shiny dashboard with users by ids.
-
+        Share a shiny dashboard with organizations by ids.
         Args:
             shiny_dashboard_id:
                 A string denoting the id of the shiny dashboard.
-            user_ids:
-                A list of strings denoting ids of users to share with.
-            organization_ids: 
+            organization_ids:
                 A list of strings denoting ids of organizations to share with.
-
         Returns:
             The requests response of the lana api call.
         """
         body = {
-            "sharedInformation": {
-                "userIds": user_ids,
-                "organizationIds": organization_ids
-            }
+            "shareWithOrganizations": organization_ids
         }
-        return self.patch(f"/api/shiny-dashboards/{shiny_dashboard_id}",
-                          data=body, **kwargs)
+        return self.patch(f"/api/shiny-dashboards/{shiny_dashboard_id}/sharing",
+                          json=body, **kwargs)
 
     def connect_shiny_dashboard(self, log_id, shiny_dashboard_id, **kwargs) \
             -> Response:

--- a/tests/README.md
+++ b/tests/README.md
@@ -11,5 +11,5 @@
     }
     ```
 * To run the tests contained in `test_users.py` a json with credentials for a user with the role user admin have to be provided in a file named `config_useradmin.json`. The format has to be the same as `config.json`. Both users have to live in the same organisation on the same LANA Process Mining instance.
-* We require the r analyst role to have access to one log named `Incident_management.csv`, one shiny dashboard named `incident-test-shiny-dashboard` and one dashboard named `incident-test-dashboard`.
+* We require the r analyst role to have access to one log named `Incident_Management.csv`, one shiny dashboard named `incident-test-shiny-dashboard` and one dashboard named `incident-test-dashboard`. The dashboard and shiny dashboard don't need to be connected to a log. The shiny dashboard also doesn't need to contain actual code as we just use its metadata for the tests.
 * [pytest](https://docs.pytest.org/en/latest/) is required to run the tests. It is included in the shipped conda environment.

--- a/tests/README.md
+++ b/tests/README.md
@@ -11,5 +11,5 @@
     }
     ```
 * To run the tests contained in `test_users.py` a json with credentials for a user with the role user admin have to be provided in a file named `config_useradmin.json`. The format has to be the same as `config.json`. Both users have to live in the same organisation on the same LANA Process Mining instance.
-* We require the r analyst role to have access to one log named `Incident_management.csv`.
+* We require the r analyst role to have access to one log named `Incident_management.csv`, one shiny dashboard named `incident-test-shiny-dashboard` and one dashboard named `incident-test-dashboard`.
 * [pytest](https://docs.pytest.org/en/latest/) is required to run the tests. It is included in the shipped conda environment.

--- a/tests/test_dashboards.py
+++ b/tests/test_dashboards.py
@@ -17,9 +17,9 @@ class TestDashboardAPI(unittest.TestCase):
         id_ = cls.api.get_dashboard_id('pylana-dashboard')
         cls.api.delete_dashboard(id_)
 
-        dashboard_id = cls.api.get_dashboard_id('incident-test-dashboard')
-        cls.api.unshare_dashboard(dashboard_id,
-                                  [cls.api.user.organization_id]).json()
+        test_dashboard_id_ = cls.api.get_dashboard_id('incident-test-dashboard')
+        cls.api.unshare_dashboard(test_dashboard_id_,
+                                  [cls.api.user.organization_id])
         
     def test_list_dashboards(self):
         dashboards = self.api.list_dashboards()
@@ -48,8 +48,8 @@ class TestDashboardAPI(unittest.TestCase):
             _ = self.api.get_dashboard('never-ever-matches-a-dashboard')
 
     def test_get_dashboard_id(self):
-        dashboard_id = self.api.get_dashboard_id('incident-test-dashboard')
-        self.assertIsInstance(dashboard_id, str)
+        test_dashboard_id = self.api.get_dashboard_id('incident-test-dashboard')
+        self.assertIsInstance(test_dashboard_id, str)
 
         with self.assertRaises(Exception):
             _ = self.api.get_dashboard_id('never-ever-matches-a-dashboard')
@@ -58,9 +58,9 @@ class TestDashboardAPI(unittest.TestCase):
         id_ = self.api.get_dashboard_id('incident-test-dashboard')
 
         actual = self.api.share_dashboard(id_,
-                                                  [self.api.user.organization_id]).json()
+                                          [self.api.user.organization_id]).json()
 
         expected = {'sharing': {'numFailures': 0, 'numSuccesses': 1},
-                            'unsharing': {'numFailures': 0, 'numSuccesses': 0}}
+                    'unsharing': {'numFailures': 0, 'numSuccesses': 0}}
 
         self.assertDictEqual(actual, expected)

--- a/tests/test_dashboards.py
+++ b/tests/test_dashboards.py
@@ -16,6 +16,10 @@ class TestDashboardAPI(unittest.TestCase):
     def tearDownClass(cls) -> None:
         id_ = cls.api.get_dashboard_id('pylana-dashboard')
         cls.api.delete_dashboard(id_)
+
+        dashboard_id = cls.api.get_dashboard_id('incident-test-dashboard')
+        cls.api.unshare_dashboard(dashboard_id,
+                                  [cls.api.user.organization_id]).json()
         
     def test_list_dashboards(self):
         dashboards = self.api.list_dashboards()
@@ -37,26 +41,26 @@ class TestDashboardAPI(unittest.TestCase):
         self.assertDictEqual(resp_create, resp_get)
 
     def test_get_dashboard(self):
-        dashboard = self.api.describe_dashboard('pylana-test-log-.*')
-        self.assertEqual(dashboard.get('title'), 'pylana-test-log-from-df')
+        dashboard = self.api.describe_dashboard('incident.*')
+        self.assertEqual(dashboard.get('title'), 'incident-test-dashboard')
 
         with self.assertRaises(Exception):
             _ = self.api.get_dashboard('never-ever-matches-a-dashboard')
 
     def test_get_dashboard_id(self):
-        dashboard_id = self.api.get_dashboard_id('pylana-test-log-from-df')
+        dashboard_id = self.api.get_dashboard_id('incident-test-dashboard')
         self.assertIsInstance(dashboard_id, str)
 
         with self.assertRaises(Exception):
             _ = self.api.get_dashboard_id('never-ever-matches-a-dashboard')
 
     def test_share_dashboard(self):
-        id_ = self.api.get_dashboard_id('pylana-test-log-from-df')
+        id_ = self.api.get_dashboard_id('incident-test-dashboard')
 
-        actual = self.api.share_dashboard(id_,
-                                          ['b7853d9b-8ca6-4a33-8892-0f172a9aeb09']).json()
+        actual_sharing = self.api.share_dashboard(id_,
+                                                  [self.api.user.organization_id]).json()
 
-        expected = {'sharing': {'numFailures': 0, 'numSuccesses': 1},
-                    'unsharing': {'numFailures': 0, 'numSuccesses': 0}}
+        expected_sharing = {'sharing': {'numFailures': 0, 'numSuccesses': 1},
+                            'unsharing': {'numFailures': 0, 'numSuccesses': 0}}
 
-        self.assertDictEqual(actual, expected)
+        self.assertDictEqual(actual_sharing, expected_sharing)

--- a/tests/test_dashboards.py
+++ b/tests/test_dashboards.py
@@ -15,11 +15,11 @@ class TestDashboardAPI(unittest.TestCase):
     @classmethod
     def tearDownClass(cls) -> None:
         id_ = cls.api.get_dashboard_id('pylana-dashboard')
-        cls.api.delete_dashboard(id_)
+        _ = cls.api.delete_dashboard(id_)
 
         test_dashboard_id_ = cls.api.get_dashboard_id('incident-test-dashboard')
-        cls.api.unshare_dashboard(test_dashboard_id_,
-                                  [cls.api.user.organization_id])
+        _ = cls.api.unshare_dashboard(test_dashboard_id_,
+                                      [cls.api.user.organization_id])
         
     def test_list_dashboards(self):
         dashboards = self.api.list_dashboards()

--- a/tests/test_dashboards.py
+++ b/tests/test_dashboards.py
@@ -57,10 +57,10 @@ class TestDashboardAPI(unittest.TestCase):
     def test_share_dashboard(self):
         id_ = self.api.get_dashboard_id('incident-test-dashboard')
 
-        actual_sharing = self.api.share_dashboard(id_,
+        actual = self.api.share_dashboard(id_,
                                                   [self.api.user.organization_id]).json()
 
-        expected_sharing = {'sharing': {'numFailures': 0, 'numSuccesses': 1},
+        expected = {'sharing': {'numFailures': 0, 'numSuccesses': 1},
                             'unsharing': {'numFailures': 0, 'numSuccesses': 0}}
 
-        self.assertDictEqual(actual_sharing, expected_sharing)
+        self.assertDictEqual(actual, expected)

--- a/tests/test_dashboards.py
+++ b/tests/test_dashboards.py
@@ -17,8 +17,8 @@ class TestDashboardAPI(unittest.TestCase):
         id_ = cls.api.get_dashboard_id('pylana-dashboard')
         _ = cls.api.delete_dashboard(id_)
 
-        test_dashboard_id_ = cls.api.get_dashboard_id('incident-test-dashboard')
-        _ = cls.api.unshare_dashboard(test_dashboard_id_,
+        test_dashboard_id = cls.api.get_dashboard_id('incident-test-dashboard')
+        _ = cls.api.unshare_dashboard(test_dashboard_id,
                                       [cls.api.user.organization_id])
         
     def test_list_dashboards(self):

--- a/tests/test_dashboards.py
+++ b/tests/test_dashboards.py
@@ -49,3 +49,14 @@ class TestDashboardAPI(unittest.TestCase):
 
         with self.assertRaises(Exception):
             _ = self.api.get_dashboard_id('never-ever-matches-a-dashboard')
+
+    def test_share_dashboard(self):
+        id_ = self.api.get_dashboard_id('pylana-test-log-from-df')
+
+        actual = self.api.share_dashboard(id_,
+                                          ['b7853d9b-8ca6-4a33-8892-0f172a9aeb09']).json()
+
+        expected = {'sharing': {'numFailures': 0, 'numSuccesses': 1},
+                    'unsharing': {'numFailures': 0, 'numSuccesses': 0}}
+
+        self.assertDictEqual(actual, expected)

--- a/tests/test_shiny_dashboards.py
+++ b/tests/test_shiny_dashboards.py
@@ -38,3 +38,14 @@ class TestDashboardAPI(unittest.TestCase):
 
         with self.assertRaises(Exception):
             _ = self.api.get_shiny_dashboard_id('1212')
+
+    def test_share_shiny_dashboard(self):
+        id_ = self.api.get_shiny_dashboard_id('incident-test-dashboard')
+
+        actual = self.api.share_shiny_dashboard(id_,
+                                                ['b7853d9b-8ca6-4a33-8892-0f172a9aeb09']).json()
+
+        expected = {'sharing': {'numFailures': 0, 'numSuccesses': 1},
+                    'unsharing': {'numFailures': 0, 'numSuccesses': 0}}
+
+        self.assertDictEqual(actual, expected)

--- a/tests/test_shiny_dashboards.py
+++ b/tests/test_shiny_dashboards.py
@@ -12,6 +12,15 @@ class TestDashboardAPI(unittest.TestCase):
             cls.credentials = json.load(f)
         cls.api = create_api(verify=True, **cls.credentials)
 
+    @classmethod
+    def tearDownClass(cls) -> None:
+        id_ = cls.api.get_shiny_dashboard_id('pylana-shiny-dashboard')
+        cls.api.delete_dashboard(id_)
+
+        shiny_dashboard_id = cls.api.get_shiny_dashboard_id('incident-test-shiny-dashboard')
+        cls.api.unshare_dashboard(shiny_dashboard_id,
+                                  [cls.api.user.organization_id]).json()
+
     def test_list(self):
         shiny_dashboards = self.api.list_shiny_dashboards()
         self.assertGreaterEqual(len(shiny_dashboards), 1)
@@ -21,29 +30,25 @@ class TestDashboardAPI(unittest.TestCase):
         resp_describe = self.api.describe_shiny_dashboard('pylana-shiny-dashboard')
         self.assertDictEqual(resp_create, resp_describe)
 
-        id_ = self.api.get_shiny_dashboard_id('pylana-shiny-dashboard')
-        resp_delete = self.api.delete_shiny_dashboard(id_)
-        self.assertEqual(resp_delete.status_code, 200)
-
     def test_describe(self):
         shiny_dashboard = self.api.describe_shiny_dashboard('incident-test-.*')
-        self.assertEqual(shiny_dashboard.get('name'), 'incident-test-dashboard')
+        self.assertEqual(shiny_dashboard.get('name'), 'incident-test-shiny-dashboard')
 
         with self.assertRaises(Exception):
             _ = self.api.describe_shiny_dashboard('never-ever-matches-a-shiny_dashboard')
 
     def test_get_shiny_dashboard_id(self):
-        shiny_dashboard_id = self.api.get_shiny_dashboard_id('incident-test-dashboard')
-        self.assertEqual(shiny_dashboard_id, 'fc474eec-922c-4716-a71d-2fe60e53f9b9')
+        shiny_dashboard_id = self.api.get_shiny_dashboard_id('incident-test-shiny-dashboard')
+        self.assertIsInstance(shiny_dashboard_id, str)
 
         with self.assertRaises(Exception):
             _ = self.api.get_shiny_dashboard_id('1212')
 
     def test_share_shiny_dashboard(self):
-        id_ = self.api.get_shiny_dashboard_id('incident-test-dashboard')
+        shiny_dashboard_id = self.api.get_shiny_dashboard_id('incident-test-shiny-dashboard')
 
-        actual = self.api.share_shiny_dashboard(id_,
-                                                ['b7853d9b-8ca6-4a33-8892-0f172a9aeb09']).json()
+        actual = self.api.share_shiny_dashboard(shiny_dashboard_id,
+                                                [self.api.user.organization_id]).json()
 
         expected = {'sharing': {'numFailures': 0, 'numSuccesses': 1},
                     'unsharing': {'numFailures': 0, 'numSuccesses': 0}}

--- a/tests/test_shiny_dashboards.py
+++ b/tests/test_shiny_dashboards.py
@@ -17,9 +17,9 @@ class TestDashboardAPI(unittest.TestCase):
         id_ = cls.api.get_shiny_dashboard_id('pylana-shiny-dashboard')
         cls.api.delete_dashboard(id_)
 
-        shiny_dashboard_id = cls.api.get_shiny_dashboard_id('incident-test-shiny-dashboard')
-        cls.api.unshare_dashboard(shiny_dashboard_id,
-                                  [cls.api.user.organization_id]).json()
+        test_shiny_dashboard_id_ = cls.api.get_shiny_dashboard_id('incident-test-shiny-dashboard')
+        cls.api.unshare_dashboard(test_shiny_dashboard_id_,
+                                  [cls.api.user.organization_id])
 
     def test_list(self):
         shiny_dashboards = self.api.list_shiny_dashboards()

--- a/tests/test_shiny_dashboards.py
+++ b/tests/test_shiny_dashboards.py
@@ -15,11 +15,11 @@ class TestDashboardAPI(unittest.TestCase):
     @classmethod
     def tearDownClass(cls) -> None:
         id_ = cls.api.get_shiny_dashboard_id('pylana-shiny-dashboard')
-        cls.api.delete_dashboard(id_)
+        cls.api.delete_shiny_dashboard(id_)
 
         test_shiny_dashboard_id_ = cls.api.get_shiny_dashboard_id('incident-test-shiny-dashboard')
-        cls.api.unshare_dashboard(test_shiny_dashboard_id_,
-                                  [cls.api.user.organization_id])
+        cls.api.unshare_shiny_dashboard(test_shiny_dashboard_id_,
+                                        [cls.api.user.organization_id])
 
     def test_list(self):
         shiny_dashboards = self.api.list_shiny_dashboards()

--- a/tests/test_shiny_dashboards.py
+++ b/tests/test_shiny_dashboards.py
@@ -17,8 +17,8 @@ class TestDashboardAPI(unittest.TestCase):
         id_ = cls.api.get_shiny_dashboard_id('pylana-shiny-dashboard')
         _ = cls.api.delete_shiny_dashboard(id_)
 
-        test_shiny_dashboard_id_ = cls.api.get_shiny_dashboard_id('incident-test-shiny-dashboard')
-        _ = cls.api.unshare_shiny_dashboard(test_shiny_dashboard_id_,
+        test_shiny_dashboard_id = cls.api.get_shiny_dashboard_id('incident-test-shiny-dashboard')
+        _ = cls.api.unshare_shiny_dashboard(test_shiny_dashboard_id,
                                             [cls.api.user.organization_id])
 
     def test_list(self):

--- a/tests/test_shiny_dashboards.py
+++ b/tests/test_shiny_dashboards.py
@@ -15,11 +15,11 @@ class TestDashboardAPI(unittest.TestCase):
     @classmethod
     def tearDownClass(cls) -> None:
         id_ = cls.api.get_shiny_dashboard_id('pylana-shiny-dashboard')
-        cls.api.delete_shiny_dashboard(id_)
+        _ = cls.api.delete_shiny_dashboard(id_)
 
         test_shiny_dashboard_id_ = cls.api.get_shiny_dashboard_id('incident-test-shiny-dashboard')
-        cls.api.unshare_shiny_dashboard(test_shiny_dashboard_id_,
-                                        [cls.api.user.organization_id])
+        _ = cls.api.unshare_shiny_dashboard(test_shiny_dashboard_id_,
+                                            [cls.api.user.organization_id])
 
     def test_list(self):
         shiny_dashboards = self.api.list_shiny_dashboards()


### PR DESCRIPTION
This PR contains a fix for the sharing of dashboards and shiny dashboards.

The endpoint used for sharing was changed to `/api/{resource_id}/sharing`.

In addition a fix for the `describe_dashboard_items()` function was included where a non-existing function was referenced and some doc-strings were updated for accuracy.