### PR TITLE
Not prepending 'API-Key' string in front of token of auth-header.

### DIFF
--- a/pylana/api.py
+++ b/pylana/api.py
@@ -11,7 +11,7 @@ from pylana.structures import User
 
 
 def _create_authorization_header(token: str) -> dict:
-    return {"Authorization": f"API-Key {token}"}
+    return {"Authorization": f"{token}"}
 
 
 @expect_json

--- a/pylana/api.py
+++ b/pylana/api.py
@@ -16,7 +16,7 @@ def _create_authorization_header(token: str) -> dict:
     if token[:(len(token_api))] == token_api or token[:(len(token_bearer))] == token_bearer:
         return {"Authorization": f"{token}"}
     else:
-        return {"Authorization": f""}
+        return {"Authorization": ""}
 
 
 @expect_json

--- a/pylana/api.py
+++ b/pylana/api.py
@@ -11,7 +11,12 @@ from pylana.structures import User
 
 
 def _create_authorization_header(token: str) -> dict:
-    return {"Authorization": f"{token}"}
+    token_bearer = "Bearer"
+    token_api = "API"
+    if token[:(len(token_api))] == token_api or token[:(len(token_bearer))] == token_bearer:
+        return {"Authorization": f"{token}"}
+    else:
+        return {"Authorization": f""}
 
 
 @expect_json

--- a/pylana/api.py
+++ b/pylana/api.py
@@ -13,7 +13,7 @@ from pylana.structures import User
 def _create_authorization_header(token: str) -> dict:
     token_bearer = "Bearer"
     token_api = "API"
-    if token[:(len(token_api))] == token_api or token[:(len(token_bearer))] == token_bearer:
+    if token[:(len(token_api))] == token_api or token[:(len(token_bearer))] == token_bearer or len(token) == 32:
         return {"Authorization": f"{token}"}
     else:
         return {"Authorization": ""}


### PR DESCRIPTION
This is a piece of a set of modifications that would allow the front-end to use a _bearer_ token to be passed.


## The reason for this change

In particular, one cannot assume, in general, that the _Authorization_ header always gets created using an API-Key. This updates puts the caller (client/user) to be responsible regarding the type of token to be used (API-key or Bearer) when performing authentication against the mining backend.

The change is required to be in effect, potentially, by the time when API-Key will not be supported any more. This also includes the potential change when the mining frontend will stop using API-Key as a means of authentication for custom dashboards.

## Future task(s)

 - Release a new version PyLana which is potentially backward compatible (otherwise use version constraints on the end-user side)
 - Have PyLana package creation part of CI pipeline
 - Uploading the created package to PiPy, so pip can install it.
 - In case we want to avoid creating a package, PyLana shall be incorporated in some ways into the `dashboard_components` repository.
 - Use a _sum-type_ to distinguish parsed authorization header values. 